### PR TITLE
Fix message source encoding

### DIFF
--- a/src/main/java/com/mmabas77/baseswingfxboot/config/I18NConfig.java
+++ b/src/main/java/com/mmabas77/baseswingfxboot/config/I18NConfig.java
@@ -13,6 +13,7 @@ public class I18NConfig {
                 new ReloadableResourceBundleMessageSource();
 
         resourceBundleMessageSource.setBasename("classpath:i18n/messages");
+        resourceBundleMessageSource.setDefaultEncoding("UTF-8");
         resourceBundleMessageSource.setCacheSeconds(1800);
 
         return resourceBundleMessageSource;


### PR DESCRIPTION
## Summary
- specify UTF-8 encoding for I18N message source

## Testing
- `bash mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683faccb00a88321b01de3cab380652b