### PR TITLE
Add context bean check in tests

### DIFF
--- a/src/test/java/com/mmabas77/baseswingfxboot/BaseSwingFxBootApplicationTests.java
+++ b/src/test/java/com/mmabas77/baseswingfxboot/BaseSwingFxBootApplicationTests.java
@@ -1,13 +1,21 @@
 package com.mmabas77.baseswingfxboot;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 class BaseSwingFxBootApplicationTests {
 
+    @Autowired
+    ApplicationContext context;
+
     @Test
     void contextLoads() {
+        assertNotNull(context.getBean("messageSource"));
     }
 
 }


### PR DESCRIPTION
## Summary
- inject `ApplicationContext` in `BaseSwingFxBootApplicationTests`
- verify that `messageSource` bean is available

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fadb6246483219b1c5bdbf919a17e