### PR TITLE
Fix runner path handling

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -1,1 +1,3 @@
-"./bin/javaw" -jar output.jar
+DIR="$(cd "$(dirname "$0")" && pwd)"
+"$DIR/bin/javaw" -jar "$DIR/output.jar"
+


### PR DESCRIPTION
## Summary
- make `runner.sh` use its own directory to find java

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683fadd3b56c8321a87c8f477dc7d026